### PR TITLE
RDK-491: Ensure proper dependency between mesh agent and wifi service

### DIFF
--- a/source/MeshAgentSsp/Makefile.am
+++ b/source/MeshAgentSsp/Makefile.am
@@ -25,4 +25,4 @@ lib_LTLIBRARIES = libMeshAgentSsp.la
 
 libMeshAgentSsp_la_CPPFLAGS = -I$(top_srcdir)/source/MeshAgentCore -I$(top_srcdir)/source/MeshAgentSsp -I$(top_srcdir)/source/include -I${PKG_CONFIG_SYSROOT_DIR}$(includedir)/ovsagent
 libMeshAgentSsp_la_SOURCES = ssp_messagebus_interface.c ssp_main.c ssp_action.c plugin_main.c cosa_meshagent_internal.c cosa_meshagent_dml.c cosa_apis_util.c cosa_mesh_apis.c mesh_client_table.c cosa_webconfig_api.c helpers.c cosa_mesh_parodus.c ethpod_error_det.c
-libMeshAgentSsp_la_LDFLAGS = -lccsp_common -ldl -rdynamic -lutapi -lutctx -lulog -lwebconfig_framework -llibparodus -lmsgpackc -ltrower-base64 -lprint_uptime -lsecure_wrapper -lz -lpthread -lrt  $(SYSTEMD_LDFLAGS)
+libMeshAgentSsp_la_LDFLAGS = -lccsp_common -ldl -rdynamic -lutapi -lutctx -lulog -lwebconfig_framework -llibparodus -lmsgpackc -ltrower-base64 -lprint_uptime -lsecure_wrapper -lz -lpthread -lrt -lsystemd  $(SYSTEMD_LDFLAGS)

--- a/systemd_units/meshAgent.service
+++ b/systemd_units/meshAgent.service
@@ -22,7 +22,7 @@ Description=Mesh Agent service
 ConditionPathExists=/tmp/wifi_initialized
 
 [Service]
-Type=forking
+Type=notify
 Environment="Subsys=eRT."
 Environment="LOG4C_RCPATH=/etc"
 EnvironmentFile=/etc/device.properties

--- a/systemd_units/meshwifi.service
+++ b/systemd_units/meshwifi.service
@@ -18,7 +18,10 @@
 ##########################################################################
 [Unit]
 Description=Mesh Wifi service
-ConditionPathExists=/tmp/wifi_initialized
+# Mesh Service needs
+#  - wifi initialized
+#  - source providing Mesh.State and Mesh.URL
+After=meshAgent.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Mesh agent is source of mesh_url and mesh_state information.
This needs to be available while mesh wifi service is starting.
The forking status of meshAgent service is not enough because of
internal threads need complete registering at message bus to
become really ready.